### PR TITLE
Optimize processor payload timestamp generation

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 #include <cstring>
 #include <curl/curl.h>
 #include <chrono>
+#include <ctime>
 #include <thread>
 #include <atomic>
 #include <map>
@@ -598,29 +599,31 @@ private:
     static pair<string, uint64_t> create_processor_payload(string& json) {
         //const auto start = get_now();
 
-        // ---- Fast timestamp formatting ----
-        char requestedAt[32];
-        auto now = chrono::system_clock::now();
-        long long ms_since_epoch = chrono::duration_cast<chrono::milliseconds>(now.time_since_epoch()).count();
-        ms_since_epoch = (ms_since_epoch / 1000) * 1000; // truncate to seconds
-        time_t t = ms_since_epoch / 1000;
-        tm tm{};
-        gmtime_r(&t, &tm);
+        thread_local char requestedAt[32];
+        thread_local time_t last_sec = 0;
+        thread_local size_t ts_len = 0;
 
-        snprintf(requestedAt, sizeof(requestedAt),
-                 "%04d-%02d-%02dT%02d:%02d:%02d.000Z",
-                 tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
-                 tm.tm_hour, tm.tm_min, tm.tm_sec);
+        time_t now = time(nullptr);
+        if (now != last_sec) {
+            last_sec = now;
+            tm tm{};
+            gmtime_r(&now, &tm);
+            ts_len = snprintf(requestedAt, sizeof(requestedAt),
+                             "%04d-%02d-%02dT%02d:%02d:%02d.000Z",
+                             tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
+                             tm.tm_hour, tm.tm_min, tm.tm_sec);
+        }
+        uint64_t ms_since_epoch = static_cast<uint64_t>(now) * 1000;
 
-        // remove lastcharacter
         json.pop_back();
-
-        // add requestedAt field
-        json += R"(,"requestedAt":")" + string(requestedAt) + R"("})";
+        json.reserve(json.size() + 40);
+        json.append(R"(,"requestedAt":")");
+        json.append(requestedAt, ts_len);
+        json.append(R"("})");
 
         //record_profiler_value("create_processor_payload", start);
 
-        return {json, static_cast<uint64_t>(ms_since_epoch)};
+        return {std::move(json), ms_since_epoch};
     }
 
     static bool send_to_processor(const string& base, const string& payload, double& elapsed, long& code) {


### PR DESCRIPTION
## Summary
- use `time()` and a thread-local cache for formatted timestamps
- reserve and append when building processor payload to reduce allocations

## Testing
- `cmake ..`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_689f3eb55c0883258604f13e5995fabd